### PR TITLE
rework asSymbolic; __ -> _

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 *.jl.cov
 *.jl.mem
 /docs/build/
+/docs/const
+/docs/import
 .CondaPkg/*

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -1,6 +1,6 @@
 # Basic overview
 
-An interface between `Julia` and SymPy requires a few things. `PythonCall` can call into an underlying sympy library, for example
+An interface between `Julia` and SymPy requires a connection between the two languages. The `PythonCall` package provides a means to  call into an underlying sympy library in `Python`. For example
 
 ```julia
 julia> import PythonCall
@@ -11,7 +11,7 @@ Python: NULL
 julia> PythonCall.pycopy!(_sympy_, PythonCall.pyimport("sympy"));
 ```
 
-The `_sympy_` object holds references to the underlying sympy library. For example, we can create a symbolic variable and call the `sin` function on it as follows:
+The `_sympy_` object holds references to the underlying sympy library. As an example, the following creates a symbolic variable, `x`, and calls the `sin` function on it:
 
 ```julia
 julia> x = _sympy_.symbols("x")
@@ -48,20 +48,22 @@ julia> using SymPyPythonCall
 ```
 
 ```jldoctest overview
-julia> x = symbols("x")
+julia> x = symbols("x") # or @syms x
 x
 
 julia> simplify(2sin(x)*cos(x))
 sin(2*x)
 ```
 
-The package also provides methods for some sympy methods, such as `simplify` above. To make this work, there needs to be a means to take `Sym` objects to the `Py` counterparts and to take `Py` objects to `Sym`. As these conversions may be type dependent two operators (with the unicode equivalents `↓` and  `↑`) are used internally to allow the definition along these lines:
+The package also provides methods for some sympy methods, such as `simplify` above. To make this work, there needs to be a means to take `Sym` objects to their `Py` counterparts and a means to take `Py` objects to a symbolic type. As these conversions may be type dependent two operators (with the unicode equivalents `↓` and  `↑`) are used internally to allow the definition along these lines:
 
 ```
 simplify(x::Sym, args...; kwargs...) = ↑(sympy.simplify(↓(x), ↓(args)...; ↓(kwargs)...))
 ```
 
-The `expand_log` function is not wrapped as such, but can be called from the `sympy` object exported by `SymPyPythonCall`:
+(Though there is some overhead introduced, it does not seem to be significant compared to computational cost of most symbolic computations.)
+
+The `expand_log` function is not wrapped as such, but can still be called from the `sympy` object exported by `SymPyPythonCall`:
 
 ```jldoctest overview
 julia> @syms x::real
@@ -78,7 +80,7 @@ Methods of `sympy` are also called using the conversion operators above.
 
 ## Using other SymPy modules
 
-We follow part of the `SymPy` docs to see how to access one of the numerous external modules of `sympy` beyond those exposed immediately by `SymPy`.
+We follow part of the `SymPy` docs to see how to access one of the numerous external modules of `sympy` beyond those exposed immediately by `SymPy`. In this case, the `stats` module.
 
 
 
@@ -106,51 +108,54 @@ julia> stats.variance(X)
 Python: σ**2
 ```
 
-The one thing to note is the method calls return `Py` objects, as there is no intercepting of the method calls done the way there is for the `sympy` module. The `Sym` command can be used to wrap the output:
+The one thing to note is the method calls return `Py` objects, as there is no intercepting of the method calls done the way there is for the `sympy` module. For `Sym` objects, like `sympy`, the `getproperty` method is overridden to wrap any underlying Python method in an internal `SymbolicCallable` type, obviating the need to call `Sym` as above. This can be done here, as follows:
 
 ```jldoctest overview
-julia> stats.variance(X) |> Sym
+julia> stats = Sym(stats);
+
+julia> stats.variance(X)
 σ^2
 ```
 
-The methods in the `stats` module are qualified with the module name above.
-
-Next we see that statements like $P(X > \mu)$ can be answered specifying the inequality using `sympy.Gt` in the following:
+Next statements like $P(X > \mu)$ can be answered by specifying the inequality using `Gt` in the following:
 
 ```jldoctest overview
-julia> stats.P(sympy.Gt(X, μ))
-Python: 1/2
+julia> stats.P(Gt(X, μ))
+1/2
 ```
+
+The unicode `≧` operator (`\geqq[tab]`) is an infix alternative to `Gt`.
 
 A typical calculation for the normal distribution is the area one or more standard deviations larger than the mean:
 
 ```jldoctest overview
-julia> stats.P(sympy.Gt(X, μ + 1σ)) |> Sym
+julia> stats.P(X ≧ μ + 1 * σ)
 sqrt(2)*(-sqrt(2)*pi*exp(1/2)*erf(sqrt(2)/2)/2 + sqrt(2)*pi*exp(1/2)/2)*exp(-1/2)/(2*pi)
 ```
 
 The familiar  answer could be found by calling `N` or `evalf`.
 
-We show one more distribution, the uniform over $[a,b]$:
+One more distribution is illusrated, the uniform distribution over a symbolic interval $[a,b]$:
 
 ```jldoctest overview
 julia> @syms a::real b::real
 (a, b)
 
 julia> U = stats.Uniform("U", a, b)
-Python: U
+U
 
-julia> stats.E(U) |> simplify |> println
+julia> stats.E(U)
 a/2 + b/2
 
-julia> stats.variance(U) |> Sym |> simplify |> factor |> println
+julia> stats.variance(U) |> factor
 (a - b)^2/12
 ```
 
-----
+## Different output types
 
-Not all outputs are so simple to incorporate. `PythonCall` does a good job of converting the arguments from `Julia` to Python, but the conversion from a Python (SymPy) structure back to a workable `Julia` structure can require some massaging.
-
+`SymPyPythonCall` provides a few conversions into containers of symbolic objects, like for lists, tuples, finite sets, and matrices.
+Not all outputs are so simple to incorporate and are simply wrapped in the `Sym` type.
+Conversion to a workable `Julia` structure can require some massaging. This example shows how to get at the pieces of the `Piecewise` type.
 
 The output of many integration problems is a piecewise function:
 
@@ -163,15 +168,26 @@ Piecewise((x^(n + 1)/(n + 1), Ne(n, -1)), (log(x), True))
 ```
 
 
-The `u` object is of type `Sym`, but there are no methods for working with it. The `.args` call will break this into its argument, which again will by symbolic. We call the `.py` attribute of the `Sym` object to get an iterable:
-
-
-
+The `u` object is of type `Sym`, but there are no methods for working with it. The `.args` call will break this into its argument, which again will by symbolic. The `SymPyPythonCall.Introspection.args` function will perform the same thing.
 
 ```jldoctest overview
-julia> [Sym(t[1]) => Sym(t[0]) for t ∈ u.args.py]
-2-element Vector{Pair{Sym, Sym}}:
- Ne(n, -1) => x^(n + 1)/(n + 1)
+julia> as = SymPyPythonCall.Introspection.args(u)
+((x^(n + 1)/(n + 1), Ne(n, -1)), (log(x), True))
+```
+
+The `as` object is a tuple of `Sym` objects. Consider the first one:
+
+```jldoctest overview
+julia> c1 = first(as)
+(x^(n + 1)/(n + 1), Ne(n, -1))
+```
+
+The value of `c1` prints as a tuple, but is of type `Sym` and sympy type `CondExprPair`. Though the underlying python type is iterable or indexable, the wrapped type is not. It can  be made iterable in a manner of ways: by finding the underlying Python object through the attribute `.py`, as in `c1.py`, or by calling the `Py` method of `PythonCall`, as in `PythonCall.Py(c1)`. More generically, `PythonCall` provides a `PyIterable` wrapper. As there is no defined `lastindex`, the latter is a bit more cumbersome to use. This pattern below, expands the conditions into a dictionary:
+
+```jldoctest overview
+julia> [Sym(a.py[1]) => Sym(a.py[0]) for a ∈ as]
+2-element Vector{Pair{Py, Py}}:
+ Ne(n, -1) => x**(n + 1)/(n + 1)
       True => log(x)
 ```
 

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -113,6 +113,9 @@ The one thing to note is the method calls return `Py` objects, as there is no in
 ```jldoctest overview
 julia> stats = Sym(stats);
 
+julia> X = stats.Normal("X", μ, σ)
+X
+
 julia> stats.variance(X)
 σ^2
 ```
@@ -186,8 +189,8 @@ The value of `c1` prints as a tuple, but is of type `Sym` and sympy type `CondEx
 
 ```jldoctest overview
 julia> [Sym(a.py[1]) => Sym(a.py[0]) for a ∈ as]
-2-element Vector{Pair{Py, Py}}:
- Ne(n, -1) => x**(n + 1)/(n + 1)
+2-element Vector{Pair{Sym, Sym}}:
+ Ne(n, -1) => x^(n + 1)/(n + 1)
       True => log(x)
 ```
 

--- a/src/SymPyPythonCall.jl
+++ b/src/SymPyPythonCall.jl
@@ -48,47 +48,48 @@ export sympy,
 
 
 # define sympy in int
-const __sympy__ = PythonCall.pynew()
-const sympy = Sym(__sympy__)
+const _sympy_ = PythonCall.pynew()
+const sympy = Sym(_sympy_)
 
 # core.sympy.numbers
-const __PI__ = PythonCall.pynew()
-const PI = Sym(__PI__)
+const _PI_ = PythonCall.pynew()
+const PI = Sym(_PI_)
 
-const __E__ = PythonCall.pynew()
-const E = Sym(__E__)
+const _E_ = PythonCall.pynew()
+const E = Sym(_E_)
 
 
-const __IM__ = PythonCall.pynew()
-const IM = Sym(__IM__)
+const _IM_ = PythonCall.pynew()
+const IM = Sym(_IM_)
 
-const __oo__ = PythonCall.pynew()
-const oo = Sym(__oo__)
+const _oo_ = PythonCall.pynew()
+const oo = Sym(_oo_)
 
-const __zoo__ = PythonCall.pynew()
-const zoo = Sym(__zoo__)
+const _zoo_ = PythonCall.pynew()
+const zoo = Sym(_zoo_)
 
-const __TRUE__ = PythonCall.pynew()
-const TRUE = Sym(__TRUE__)
+const _TRUE_ = PythonCall.pynew()
+const TRUE = Sym(_TRUE_)
 
-const __FALSE__ = PythonCall.pynew()
-const FALSE = Sym(__FALSE__)
+const _FALSE_ = PythonCall.pynew()
+const FALSE = Sym(_FALSE_)
 
-const __𝑄__ = PythonCall.pynew()
-const 𝑄 = Sym(__𝑄__)
+const _𝑄_ = PythonCall.pynew()
+const 𝑄 = Sym(_𝑄_)
 
 function __init__()
 
-    PythonCall.pycopy!(__sympy__, PythonCall.pyimport("sympy"))
+    PythonCall.pycopy!(_sympy_, PythonCall.pyimport("sympy"))
 
-    PythonCall.pycopy!(__PI__, __sympy__.pi)
-    PythonCall.pycopy!(__E__, __sympy__.E)
-    PythonCall.pycopy!(__IM__, __sympy__.I)
-    PythonCall.pycopy!(__oo__, __sympy__.oo)
-    PythonCall.pycopy!(__zoo__, __sympy__.zoo)
-    PythonCall.pycopy!(__TRUE__, pyconvert(Py, true))
-    PythonCall.pycopy!(__FALSE__, pyconvert(Py, false))
-    PythonCall.pycopy!(__𝑄__, __sympy__.Q)
+    PythonCall.pycopy!(_PI_, _sympy_.pi)
+    PythonCall.pycopy!(_E_, _sympy_.E)
+    PythonCall.pycopy!(_IM_, _sympy_.I)
+    PythonCall.pycopy!(_oo_, _sympy_.oo)
+    PythonCall.pycopy!(_zoo_, _sympy_.zoo)
+    PythonCall.pycopy!(_TRUE_, pyconvert(Py, true))
+    PythonCall.pycopy!(_FALSE_, pyconvert(Py, false))
+    PythonCall.pycopy!(_𝑄_, _sympy_.Q)
+
 
 end
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -1,4 +1,4 @@
-_symbols(a; kwargs...) = Sym(__sympy__.symbols(a; kwargs...))
+_symbols(a; kwargs...) = Sym(_sympy_.symbols(a; kwargs...))
 # split on comma (add space?)
 symbols(a; kwargs...) = contains(a, ",") ? _symbols.(split(a, ","); kwargs...) : _symbols(a; kwargs...)
 

--- a/src/gen_methods.jl
+++ b/src/gen_methods.jl
@@ -17,8 +17,21 @@ asSymbolic(x) = Sym(pyconvert(Py, x))
 asSymbolic(x::Sym) = x
 asSymbolic(x::String) = Sym(x)
 
-PyTypeName(x) = Val(Symbol(PythonCall.pyconvert_typename(pytype(x))))
-asSymbolic(x::Py) = asSymbolic(PyTypeName(x), x) # special case based on typename
+# a bit more performant than the following, but still too slow.
+#PyTypeName(x) = Symbol(PythonCall.pyconvert_typename(pytype(x)))
+# allocates muchmore than pyhash, but doesn't seem to be a bottleneck
+function PyTypeName(u)
+    v = pytype(u)
+    δ = pystr("<unknown>")
+    m = pygetattr(v,"__module__", δ)
+    m = pyconvert(Bool, m == pybuiltins.None) ? δ : m
+    a = m +  pystr(":") + pygetattr(v, "__name__", δ)
+    return pyconvert(Symbol, a)
+    #@show s
+    #s
+    :nada
+end
+asSymbolic(x::Py) = asSymbolic(Val(PyTypeName(x)), x) # special case based on typename
 
 asSymbolic(::Val{T}, x::Py) where {T} = Sym(x) # fallback
 
@@ -28,7 +41,6 @@ asSymbolic(::Val{Symbol("builtins:dict")}, x::Py) = Dict(asSymbolic(k) => asSymb
 asSymbolic(::Val{Symbol("builtins:set")}, x::Py) = Set(asSymbolic(xᵢ) for xᵢ ∈ x)
 asSymbolic(::Val{Symbol("sympy.sets.sets:FiniteSet")}, x::Py) = Set(asSymbolic(xᵢ) for xᵢ ∈ x)
 asSymbolic(::Val{Symbol("sympy.core.containers:Tuple")}, x::Py) = Tuple(asSymbolic(xᵢ) for xᵢ ∈ x)
-
 function _as_symbolic_dense_matrix(x)
     sz = pyconvert(Tuple, x.shape)
     return [asSymbolic(x.__getitem__((i-1, j-1))) for i ∈ 1:sz[1], j ∈ 1:sz[2]]
@@ -43,6 +55,49 @@ function _as_symbolic_symbolic_matrix(x)
 end
 asSymbolic(::Val{Symbol("sympy.matrices.expressions.matexpr:MatrixSymbol")}, x::Py) = _as_symbolic_symbolic_matrix(x)
 asSymbolic(::Val{Symbol("sympy.matrices.expressions.inverse:Inverse")}, x::Py) = _as_symbolic_symbolic_matrix(x)
+
+#=
+# The above `PyTypeName` is a bit more performant than PyTypeName(x) = Symbol(PythonCall.pyconvert_typename(pytype(x))) but
+# this would be much faster:
+PyTypeName(x::Py) = pyhash(pytype(x))
+# But we would need to find the hash for the selected pytypes at the time of initialization. as hashing is
+# not guaranteed to be portable. So, we would need to put the values in `__init__`, like:
+    pytypehash[pybuiltins.list]  = pyhash(pybuiltins.list)
+    asSymbolic(::Val{pyhash(pybuiltins.list)}, x::Py) = isempty(x) ? Sym[] : [asSymbolic(xᵢ) for xᵢ ∈ x] # XXX are lists Tuples or vectors???
+# The above works fine, so has promise, but for some reason doesn't work with
+   pytypehash[_sympy_.sets.sets.FiniteSet] = pyhash(_sympy_.sets.sets.FiniteSet)
+asSymbolic(::Val{pytypehash["sympy.sets.sets:FiniteSet"]}, x::Py) = Set(asSymbolic(xᵢ) for xᵢ ∈ x)
+#which is a deal breaker.
+    pytypehash[_sympy_.core.containers.Tuple] = pyhash(_sympy_.core.containers.Tuple)
+    pytypehash[_sympy_.matrices.dense.MutableDenseMatrix], pyhash(_sympy_.matrices.dense.MutableDenseMatrix)
+    pytypehash[_sympy_.matrices.dense.ImmutableDenseMatrix], pyhash(_sympy_.matrices.dense.ImmutableDenseMatrix)
+    pytypehash[_sympy_.matrices.expressions.matexpr.MatrixSymbol], pyhash(_sympy_.matrices.expressions.matexpr.MatrixSymbol)
+    pytypehash[_sympy_.matrices.expressions.inverse.Inverse], pyhash(_sympy_.matrices.expressions.inverse,Inverse)
+    asSymbolic(::Val{__finite_set()}, x::Py) = Set(asSymbolic(xᵢ) for xᵢ ∈ x)
+    asSymbolic(::Val{pyhash(_sympy_.sets.sets.FiniteSet)}, x::Py) = Set(asSymbolic(xᵢ) for xᵢ ∈ x)
+    asSymbolic(::Val{pyhash(_sympy_.core.containers.Tuple)}, x::Py) = Tuple(asSymbolic(xᵢ) for xᵢ ∈ x)
+    asSymbolic(::Val{pytypehash["builtins:list"]}, x::Py) = isempty(x) ? Sym[] : [asSymbolic(xᵢ) for xᵢ ∈ x] # XXX are lists Tuples or vectors???
+    asSymbolic(::Val{pytypehash["builtins:tuple"]}, x::Py) = Tuple(asSymbolic(xᵢ) for xᵢ ∈ x)
+    asSymbolic(::Val{pytypehash["builtins:dict"]}, x::Py) = Dict(asSymbolic(k) => asSymbolic(v) for (k,v) ∈ pyconvert(PyDict, x))
+    asSymbolic(::Val{pytypehash["builtins:set"]}, x::Py) = Set(asSymbolic(xᵢ) for xᵢ ∈ x)
+    asSymbolic(::Val{pytypehash["sympy.sets.sets:FiniteSet"]}, x::Py) = Set(asSymbolic(xᵢ) for xᵢ ∈ x)
+    asSymbolic(::Val{pytypehash["sympy.core.containers:Tuple"]}, x::Py) = Tuple(asSymbolic(xᵢ) for xᵢ ∈ x)
+
+# function _as_symbolic_dense_matrix(x)
+#     sz = pyconvert(Tuple, x.shape)
+#     return [asSymbolic(x.__getitem__((i-1, j-1))) for i ∈ 1:sz[1], j ∈ 1:sz[2]]
+# end
+# asSymbolic(::Val{pytypehash["sympy.matrices.dense:MutableDenseMatrix"]}, x::Py) = _as_symbolic_dense_matrix(x)
+# asSymbolic(::Val{pytypehash["sympy.matrices.dense:ImmutableDenseMatrix"]}, x::Py) = _as_symbolic_dense_matrix(x)
+
+# function _as_symbolic_symbolic_matrix(x)
+#     sz = pyconvert(Tuple, x.shape)
+#     !isa(sz[1], Real) && return Sym(x) # MatrixSymbol special case
+#     return [asSymbolic(x.__getitem__((i-1, j-1))) for i ∈ 1:sz[1], j ∈ 1:sz[2]]
+# end
+# asSymbolic(::Val{pytypehash["sympy.matrices.expressions.matexpr:MatrixSymbol"]}, x::Py) = _as_symbolic_symbolic_matrix(x)
+# asSymbolic(::Val{pytypehash["sympy.matrices.expressions.inverse:Inverse"]}, x::Py) = _as_symbolic_symbolic_matrix(x)
+=#
 
 # used to pass arguments down into calls
 unSym(x) = x

--- a/src/lambdify.jl
+++ b/src/lambdify.jl
@@ -34,18 +34,18 @@ end
 ## most are handled by Symbol(fnname), the following catch exceptions
 ## Hack to avoid Expr(:call,  :*,2, x)  being  2x and  not  2*x
 ## As of newer sympy versions, this is no longer needed.
-__PROD__(args...) =  prod(args)
+_PROD_(args...) =  prod(args)
 
-__ANY__(xs...) = any(xs)
-__ALL__(xs...) = all(xs)
-__ZERO__(xs...) = 0
+_ANY_(xs...) = any(xs)
+_ALL_(xs...) = all(xs)
+_ZERO_(xs...) = 0
 # not quite a match; NaN not θ(0) when evaluated at 0 w/o second argument
-__HEAVISIDE__ = (a...)  -> (a[1] < 0 ? 0 : (a[1] > 0 ? 1 : (length(a) > 1 ? a[2] : NaN)))
-#  __SYMPY__ALL__,
+_HEAVISIDE_ = (a...)  -> (a[1] < 0 ? 0 : (a[1] > 0 ? 1 : (length(a) > 1 ? a[2] : NaN)))
+#  _SYMPY_ALL_,
 fn_map = Dict(
     "Add" => :+,
     "Sub" => :-,
-    "Mul" => :((as...)->prod(as)), #:*, # :(SymPy.__PROD__)
+    "Mul" => :((as...)->prod(as)), #:*, # :(SymPy._PROD_)
     "Div" => :/,
     "Pow" => :^,
     "re"  => :real,
@@ -55,9 +55,9 @@ fn_map = Dict(
     "Max" => :max,
     "Poly" => :identity,
     "Piecewise" => :(SymPyPythonCall._piecewise),
-    "Order" => :(SymPyPythonCall.__ZERO__), # :(as...) -> 0,
-    "And" => :(SymPyPythonCall.__ALL__), #:((as...) -> all(as)), #:(&),
-    "Or" =>  :(SymPyPythonCall.__ANY__), #:((as...) -> any(as)), #:(|),
+    "Order" => :(SymPyPythonCall._ZERO_), # :(as...) -> 0,
+    "And" => :(SymPyPythonCall._ALL_), #:((as...) -> all(as)), #:(&),
+    "Or" =>  :(SymPyPythonCall._ANY_), #:((as...) -> any(as)), #:(|),
     "Less" => :(<),
     "LessThan" => :(<=),
     "StrictLessThan" => :(<),
@@ -69,7 +69,7 @@ fn_map = Dict(
     "Greater" => :(>),
     "conjugate" => :conj,
     "atan2" => :atan,
-    "Heaviside" => :(SymPyPythonCall.__HEAVISIDE__),
+    "Heaviside" => :(SymPyPythonCall._HEAVISIDE_),
 )
 
 map_fn(key, fn_map) = haskey(fn_map, key) ? fn_map[key] : Symbol(key)
@@ -227,7 +227,7 @@ function convert_expr(ex::Sym;
                       fns=Dict(), values=Dict(),
                       use_julia_code=false)
     if use_julia_code
-        body = (Meta.parse ∘ string)(__sympy__.julia_code(ex)) # issue here with 2.*...
+        body = (Meta.parse ∘ string)(_sympy_.julia_code(ex)) # issue here with 2.*...
     else
         body = walk_expression(ex, fns=fns, values=values)
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -61,6 +61,9 @@ Sym(x::Irrational{:e}) = sympy.E
 struct SymbolicCallable
     val
 end
+PythonCall.Py(x::SymbolicCallable) = x.val
+PythonCall.ispy(x::SymbolicCallable) = true
+
 Base.show(io::IO, λ::SymbolicCallable) = print(io, "Callable SymPy method")
 function (v::SymbolicCallable)(args...; kwargs...)
     ↑(v.val(unSym.(args)...; unSymkwargs(kwargs)...))
@@ -70,9 +73,10 @@ struct SymFunction <: SymbolicObject
     py::Py
 end
 PythonCall.Py(u::SymFunction) = u.py
+PythonCall.ispy(u::SymFunction) = true
 
 function SymFunction(x::AbstractString; kwargs...)
-    λ = __sympy__.Function(x; unSymkwargs(kwargs)...)
+    λ = _sympy_.Function(x; unSymkwargs(kwargs)...)
     SymFunction(λ)
 end
 (u::SymFunction)(xs...) = ↑(Py(u)(↓(xs)...))


### PR DESCRIPTION
* rework how `asSymbolic` is done
*  replace `__` (dunder) wrappers with single `_` for future proofing
* update `overview.md` doc