### PR TITLE
freeze sympycore to not break

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymPyPythonCall"
 uuid = "bc8888f7-b21e-4b7c-a06a-5d9c9496438c"
 authors = ["jverzani <jverzani@gmail.com> and contributors"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"
@@ -27,7 +27,7 @@ PythonCall = "0.9"
 SpecialFunctions = "0.8, 0.9, 0.10, 1.0, 2"
 Symbolics = "5"
 SymbolicUtils = "1"
-SymPyCore = "0.1.3, 1"
+SymPyCore = "=0.1.5, 1"
 julia = "1.6.1"
 
 


### PR DESCRIPTION
The recent change to SymPyCore was unintentionally breaking and should have had a bump indicating this. This freezes things while this package updates.